### PR TITLE
Add redirects for PolarFire SoC documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,6 +38,7 @@ include:
   - _pages
   - _docs
   - assets
+  - _redirects
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/_layouts/forward.html
+++ b/_layouts/forward.html
@@ -1,0 +1,44 @@
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    {% assign time = 0 %}
+    {% assign targetname = page.target %}
+ 
+    {% if page.time %}
+    {% assign time = page.time %}
+    {% endif %}
+    
+    {% if page.targetname %}
+    {% assign targetname = page.targetname %}
+    {% endif %}
+
+    {% capture title %}Redirecting to {{ targetname }}{% endcapture %}
+    {% if page.targettitle %}
+    {% assign title = page.targettitle %}
+    {% endif %}
+    <meta http-equiv="refresh" content="{{ time }};url={{ page.target }}"/>
+    <link rel="canonical" href="{{ page.target }}"/>
+    <title>{{ title }}</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            max-width: 40em;
+            margin: 1em auto;
+        }
+    </style>
+</head>
+<body>
+    <h1>{{ title }}</h1>
+   
+    {% if page.message %}
+    <p>{{ page.message }}</p>
+    {% else %}
+    <p>This document has moved!</p>
+    {% endif %}
+
+    <p>Redirecting to <a href="{{ page.target }}">{{ targetname }}</a> in {{ time }} seconds.</p>
+
+</body>
+</html>

--- a/_redirects/asymmetric-multiprocessing_amp.md
+++ b/_redirects/asymmetric-multiprocessing_amp.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/asymmetric-multiprocessing_amp
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/asymmetric-multiprocessing/amp.md
+targetname: asymmetric-multiprocessing_amp
+targettitle: taking you to asymmetric-multiprocessing_amp
+time: 0
+message: this page has moved
+---

--- a/_redirects/asymmetric-multiprocessing_ihc.md
+++ b/_redirects/asymmetric-multiprocessing_ihc.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/asymmetric-multiprocessing_ihc
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/asymmetric-multiprocessing/ihc.md
+targetname: asymmetric-multiprocessing_ihc
+targettitle: taking you to asymmetric-multiprocessing_ihc
+time: 0
+message: this page has moved
+---

--- a/_redirects/asymmetric-multiprocessing_rpmsg-client-drivers.md
+++ b/_redirects/asymmetric-multiprocessing_rpmsg-client-drivers.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/asymmetric-multiprocessing_rpmsg-client-drivers
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/asymmetric-multiprocessing/rpmsg-client-drivers.md
+targetname: asymmetric-multiprocessing_rpmsg-client-drivers
+targettitle: taking you to asymmetric-multiprocessing_rpmsg-client-drivers
+time: 0
+message: this page has moved
+---

--- a/_redirects/asymmetric-multiprocessing_rpmsg.md
+++ b/_redirects/asymmetric-multiprocessing_rpmsg.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/asymmetric-multiprocessing_rpmsg
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/asymmetric-multiprocessing/rpmsg.md
+targetname: asymmetric-multiprocessing_rpmsg
+targettitle: taking you to asymmetric-multiprocessing_rpmsg
+time: 0
+message: this page has moved
+---

--- a/_redirects/bare-metal-project-structure_bare-metal-software-project-structure.md
+++ b/_redirects/bare-metal-project-structure_bare-metal-software-project-structure.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/bare-metal-project-structure_bare-metal-software-project-structure
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/bare-metal-project-structure/bare-metal-software-project-structure.md
+targetname: bare-metal-project-structure_bare-metal-software-project-structure
+targettitle: taking you to bare-metal-project-structure_bare-metal-software-project-structure
+time: 0
+message: this page has moved
+---

--- a/_redirects/boot-mode-0_boot-mode-0-fundamentals.md
+++ b/_redirects/boot-mode-0_boot-mode-0-fundamentals.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/boot-mode-0_boot-mode-0-fundamentals
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/fundamentals/boot-modes/boot-mode-0/boot-mode-0-fundamentals.md
+targetname: boot-mode-0_boot-mode-0-fundamentals
+targettitle: taking you to boot-mode-0_boot-mode-0-fundamentals
+time: 0
+message: this page has moved
+---

--- a/_redirects/boot-mode-1_boot-mode-1-fundamentals.md
+++ b/_redirects/boot-mode-1_boot-mode-1-fundamentals.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/boot-mode-1_boot-mode-1-fundamentals
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/fundamentals/boot-modes/boot-mode-1/boot-mode-1-fundamentals.md
+targetname: boot-mode-1_boot-mode-1-fundamentals
+targettitle: taking you to boot-mode-1_boot-mode-1-fundamentals
+time: 0
+message: this page has moved
+---

--- a/_redirects/boot-mode-2_boot-mode-2-fundamentals.md
+++ b/_redirects/boot-mode-2_boot-mode-2-fundamentals.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/boot-mode-2_boot-mode-2-fundamentals
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/fundamentals/boot-modes/boot-mode-2/boot-mode-2-fundamentals.md
+targetname: boot-mode-2_boot-mode-2-fundamentals
+targettitle: taking you to boot-mode-2_boot-mode-2-fundamentals
+time: 0
+message: this page has moved
+---

--- a/_redirects/boot-mode-3_boot-mode-3-fundamentals.md
+++ b/_redirects/boot-mode-3_boot-mode-3-fundamentals.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/boot-mode-3_boot-mode-3-fundamentals
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/fundamentals/boot-modes/boot-mode-3/boot-mode-3-fundamentals.md
+targetname: boot-mode-3_boot-mode-3-fundamentals
+targettitle: taking you to boot-mode-3_boot-mode-3-fundamentals
+time: 0
+message: this page has moved
+---

--- a/_redirects/boot-modes_boot-modes-fundamentals.md
+++ b/_redirects/boot-modes_boot-modes-fundamentals.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/boot-modes_boot-modes-fundamentals
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/fundamentals/boot-modes/boot-modes-fundamentals.md
+targetname: boot-modes_boot-modes-fundamentals
+targettitle: taking you to boot-modes_boot-modes-fundamentals
+time: 0
+message: this page has moved
+---

--- a/_redirects/booting-from-qspi_booting-from-qspi.md
+++ b/_redirects/booting-from-qspi_booting-from-qspi.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/booting-from-qspi_booting-from-qspi
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/mpfs-icicle-kit-es/booting-from-qspi/booting-from-qspi.md
+targetname: booting-from-qspi_booting-from-qspi
+targettitle: taking you to booting-from-qspi_booting-from-qspi
+time: 0
+message: this page has moved
+---

--- a/_redirects/demo-guides_mpfs-axi4-stream-demo.md
+++ b/_redirects/demo-guides_mpfs-axi4-stream-demo.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/demo-guides_mpfs-axi4-stream-demo
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/demo-guides/mpfs-axi4-stream-demo.md
+targetname: demo-guides_mpfs-axi4-stream-demo
+targettitle: taking you to demo-guides_mpfs-axi4-stream-demo
+time: 0
+message: this page has moved
+---

--- a/_redirects/demo-guides_mpfs-pmp-demo.md
+++ b/_redirects/demo-guides_mpfs-pmp-demo.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/demo-guides_mpfs-pmp-demo
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/demo-guides/mpfs-pmp-demo.md
+targetname: demo-guides_mpfs-pmp-demo
+targettitle: taking you to demo-guides_mpfs-pmp-demo
+time: 0
+message: this page has moved
+---

--- a/_redirects/icicle-kit-sw-developer-guide_icicle-kit-sw-developer-guide.md
+++ b/_redirects/icicle-kit-sw-developer-guide_icicle-kit-sw-developer-guide.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/icicle-kit-sw-developer-guide_icicle-kit-sw-developer-guide
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/mpfs-icicle-kit-es/icicle-kit-sw-developer-guide/icicle-kit-sw-developer-guide.md
+targetname: icicle-kit-sw-developer-guide_icicle-kit-sw-developer-guide
+targettitle: taking you to icicle-kit-sw-developer-guide_icicle-kit-sw-developer-guide
+time: 0
+message: this page has moved
+---

--- a/_redirects/lc-mpfs-dev-kit_LC-MPFS-DEV-KIT_user_guide.md
+++ b/_redirects/lc-mpfs-dev-kit_LC-MPFS-DEV-KIT_user_guide.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/lc-mpfs-dev-kit_LC-MPFS-DEV-KIT_user_guide
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/lc-mpfs-dev-kit/LC-MPFS-DEV-KIT_user_guide.md
+targetname: lc-mpfs-dev-kit_LC-MPFS-DEV-KIT_user_guide
+targettitle: taking you to lc-mpfs-dev-kit_LC-MPFS-DEV-KIT_user_guide
+time: 0
+message: this page has moved
+---

--- a/_redirects/memory-hierarchy_mpfs-memory-hierarchy.md
+++ b/_redirects/memory-hierarchy_mpfs-memory-hierarchy.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/memory-hierarchy_mpfs-memory-hierarchy
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/memory-hierarchy/mpfs-memory-hierarchy.md
+targetname: memory-hierarchy_mpfs-memory-hierarchy
+targettitle: taking you to memory-hierarchy_mpfs-memory-hierarchy
+time: 0
+message: this page has moved
+---

--- a/_redirects/mpfs-dev-kit_MPFS-DEV-KIT_user_guide.md
+++ b/_redirects/mpfs-dev-kit_MPFS-DEV-KIT_user_guide.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/mpfs-dev-kit_MPFS-DEV-KIT_user_guide
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/mpfs-dev-kit/MPFS-DEV-KIT_user_guide.md
+targetname: mpfs-dev-kit_MPFS-DEV-KIT_user_guide
+targettitle: taking you to mpfs-dev-kit_MPFS-DEV-KIT_user_guide
+time: 0
+message: this page has moved
+---

--- a/_redirects/pcie_mpfs-memory-configuration.md
+++ b/_redirects/pcie_mpfs-memory-configuration.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/pcie_mpfs-memory-configuration
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/fundamentals/pcie/mpfs-memory-configuration.md
+targetname: pcie_mpfs-memory-configuration
+targettitle: taking you to pcie_mpfs-memory-configuration
+time: 0
+message: this page has moved
+---

--- a/_redirects/polarfire-soc-documentation-master_README.md
+++ b/_redirects/polarfire-soc-documentation-master_README.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/polarfire-soc-documentation-master_README
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/README.md
+targetname: polarfire-soc-documentation-master_README
+targettitle: taking you to polarfire-soc-documentation-master_README
+time: 0
+message: this page has moved
+---

--- a/_redirects/programming-spi-flash-via-libero_programming-spi-flash-via-libero.md
+++ b/_redirects/programming-spi-flash-via-libero_programming-spi-flash-via-libero.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/programming-spi-flash-via-libero_programming-spi-flash-via-libero
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/mpfs-icicle-kit-es/programming-spi-flash-via-libero/programming-spi-flash-via-libero.md
+targetname: programming-spi-flash-via-libero_programming-spi-flash-via-libero
+targettitle: taking you to programming-spi-flash-via-libero_programming-spi-flash-via-libero
+time: 0
+message: this page has moved
+---

--- a/_redirects/secure-boot_secure-boot.md
+++ b/_redirects/secure-boot_secure-boot.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/secure-boot_secure-boot
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/hart-software-services/secure-boot/secure-boot.md
+targetname: secure-boot_secure-boot
+targettitle: taking you to secure-boot_secure-boot
+time: 0
+message: this page has moved
+---

--- a/_redirects/software-development_hss-payloads.md
+++ b/_redirects/software-development_hss-payloads.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/software-development_hss-payloads
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/software-development/hss-payloads.md
+targetname: software-development_hss-payloads
+targettitle: taking you to software-development_hss-payloads
+time: 0
+message: this page has moved
+---

--- a/_redirects/software-development_multiprocessor-debugging.md
+++ b/_redirects/software-development_multiprocessor-debugging.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/software-development_multiprocessor-debugging
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/software-development/multiprocessor-debugging.md
+targetname: software-development_multiprocessor-debugging
+targettitle: taking you to software-development_multiprocessor-debugging
+time: 0
+message: this page has moved
+---

--- a/_redirects/software-development_polarfire-soc-software-tool-flow.md
+++ b/_redirects/software-development_polarfire-soc-software-tool-flow.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/software-development_polarfire-soc-software-tool-flow
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/software-development/polarfire-soc-software-tool-flow.md
+targetname: software-development_polarfire-soc-software-tool-flow
+targettitle: taking you to software-development_polarfire-soc-software-tool-flow
+time: 0
+message: this page has moved
+---

--- a/_redirects/software-development_polarfire-soc-usb.md
+++ b/_redirects/software-development_polarfire-soc-usb.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/software-development_polarfire-soc-usb
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/software-development/polarfire-soc-usb.md
+targetname: software-development_polarfire-soc-usb
+targettitle: taking you to software-development_polarfire-soc-usb
+time: 0
+message: this page has moved
+---

--- a/_redirects/updating-icicle-kit_updating-icicle-kit-design-and-linux.md
+++ b/_redirects/updating-icicle-kit_updating-icicle-kit-design-and-linux.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/updating-icicle-kit_updating-icicle-kit-design-and-linux
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/mpfs-icicle-kit-es/updating-icicle-kit/updating-icicle-kit-design-and-linux.md
+targetname: updating-icicle-kit_updating-icicle-kit-design-and-linux
+targettitle: taking you to updating-icicle-kit_updating-icicle-kit-design-and-linux
+time: 0
+message: this page has moved
+---

--- a/_redirects/watchdog-service_watchdog-service.md
+++ b/_redirects/watchdog-service_watchdog-service.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/watchdog-service_watchdog-service
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/hart-software-services/watchdog-service/watchdog-service.md
+targetname: watchdog-service_watchdog-service
+targettitle: taking you to watchdog-service_watchdog-service
+time: 0
+message: this page has moved
+---


### PR DESCRIPTION
This PR adds:
1. The ability to generate redirects using the custom "forward" layout in the _layouts directory
2. Adds redirects to PolarFire SoC documentation