### PR TITLE
Redirects: add MPFS folder redirect links

### DIFF
--- a/_redirects/asymmetric-multiprocessing.md
+++ b/_redirects/asymmetric-multiprocessing.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/asymmetric-multiprocessing
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/asymmetric-multiprocessing
+targetname: asymmetric-multiprocessing
+targettitle: taking you to asymmetric-multiprocessing
+time: 0
+message: this page has moved
+---

--- a/_redirects/bare-metal-project-structure.md
+++ b/_redirects/bare-metal-project-structure.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/bare-metal-project-structure
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/bare-metal-project-structure
+targetname: bare-metal-project-structure
+targettitle: taking you to bare-metal-project-structure
+time: 0
+message: this page has moved
+---

--- a/_redirects/boards-lc-mpfs-dev-kit.md
+++ b/_redirects/boards-lc-mpfs-dev-kit.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/boards-lc-mpfs-dev-kit
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/lc-mpfs-dev-kit
+targetname: boards-lc-mpfs-dev-kit
+targettitle: taking you to boards-lc-mpfs-dev-kit
+time: 0
+message: this page has moved
+---

--- a/_redirects/boards-mpfs-dev-kit.md
+++ b/_redirects/boards-mpfs-dev-kit.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/boards-mpfs-dev-kit
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-dev-kit
+targetname: boards-mpfs-dev-kit
+targettitle: taking you to boards-mpfs-dev-kit
+time: 0
+message: this page has moved
+---

--- a/_redirects/boards-mpfs-icicle-kit-es-booting-from-qspi.md
+++ b/_redirects/boards-mpfs-icicle-kit-es-booting-from-qspi.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/boards-mpfs-icicle-kit-es-booting-from-qspi
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-icicle-kit-es/booting-from-qspi
+targetname: boards-mpfs-icicle-kit-es-booting-from-qspi
+targettitle: taking you to boards-mpfs-icicle-kit-es-booting-from-qspi
+time: 0
+message: this page has moved
+---

--- a/_redirects/boards-mpfs-icicle-kit-es-icicle-kit-sw-developer-guide.md
+++ b/_redirects/boards-mpfs-icicle-kit-es-icicle-kit-sw-developer-guide.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/boards-mpfs-icicle-kit-es-icicle-kit-sw-developer-guide
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-icicle-kit-es/icicle-kit-sw-developer-guide
+targetname: boards-mpfs-icicle-kit-es-icicle-kit-sw-developer-guide
+targettitle: taking you to boards-mpfs-icicle-kit-es-icicle-kit-sw-developer-guide
+time: 0
+message: this page has moved
+---

--- a/_redirects/boards-mpfs-icicle-kit-es-programming-spi-flash-via-libero.md
+++ b/_redirects/boards-mpfs-icicle-kit-es-programming-spi-flash-via-libero.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/boards-mpfs-icicle-kit-es-programming-spi-flash-via-libero
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-icicle-kit-es/programming-spi-flash-via-libero
+targetname: boards-mpfs-icicle-kit-es-programming-spi-flash-via-libero
+targettitle: taking you to boards-mpfs-icicle-kit-es-programming-spi-flash-via-libero
+time: 0
+message: this page has moved
+---

--- a/_redirects/boards-mpfs-icicle-kit-es-updating-icicle-kit.md
+++ b/_redirects/boards-mpfs-icicle-kit-es-updating-icicle-kit.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/boards-mpfs-icicle-kit-es-updating-icicle-kit
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-icicle-kit-es/updating-icicle-kit
+targetname: boards-mpfs-icicle-kit-es-updating-icicle-kit
+targettitle: taking you to boards-mpfs-icicle-kit-es-updating-icicle-kit
+time: 0
+message: this page has moved
+---

--- a/_redirects/boards-mpfs-icicle-kit-es.md
+++ b/_redirects/boards-mpfs-icicle-kit-es.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/boards-mpfs-icicle-kit-es
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-icicle-kit-es
+targetname: boards-mpfs-icicle-kit-es
+targettitle: taking you to boards-mpfs-icicle-kit-es
+time: 0
+message: this page has moved
+---

--- a/_redirects/boards.md
+++ b/_redirects/boards.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/boards
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards
+targetname: boards
+targettitle: taking you to boards
+time: 0
+message: this page has moved
+---

--- a/_redirects/demo-guides.md
+++ b/_redirects/demo-guides.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/demo-guides
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/demo-guides
+targetname: demo-guides
+targettitle: taking you to demo-guides
+time: 0
+message: this page has moved
+---

--- a/_redirects/demo-mpfs-pmp-demo.md
+++ b/_redirects/demo-mpfs-pmp-demo.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/demo-mpfs-pmp-demo
+target: https://github.com/polarfire-soc/polarfire-soc-bare-metal-examples/tree/main/applications/mpfs-pmp-demo
+targetname: demo-mpfs-pmp-demo
+targettitle: taking you to demo-mpfs-pmp-demo
+time: 0
+message: this page has moved
+---

--- a/_redirects/fundamentals-boot-modes.md
+++ b/_redirects/fundamentals-boot-modes.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/fundamentals-boot-modes
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/fundamentals/boot-modes
+targetname: fundamentals-boot-modes
+targettitle: taking you to fundamentals-boot-modes
+time: 0
+message: this page has moved
+---

--- a/_redirects/fundamentals-pcie.md
+++ b/_redirects/fundamentals-pcie.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/fundamentals-pcie
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/fundamentals/pcie
+targetname: fundamentals-pcie
+targettitle: taking you to fundamentals-pcie
+time: 0
+message: this page has moved
+---

--- a/_redirects/fundamentals.md
+++ b/_redirects/fundamentals.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/fundamentals
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/fundamentals
+targetname: fundamentals
+targettitle: taking you to fundamentals
+time: 0
+message: this page has moved
+---

--- a/_redirects/hart-software-services-secure-boot.md
+++ b/_redirects/hart-software-services-secure-boot.md
@@ -1,0 +1,8 @@
+---
+layout: forward
+permalink: /redirects/hart-software-services-secure-boot
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/hart-software-services/secure-boot
+targetname: hart-software-services-secure-boot
+time: 0
+message: this page has moved
+---

--- a/_redirects/hart-software-services-watchdog-service.md
+++ b/_redirects/hart-software-services-watchdog-service.md
@@ -1,0 +1,8 @@
+---
+layout: forward
+permalink: /redirects/hart-software-services-watchdog-service
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/hart-software-services/watchdog-service
+targetname: hart-software-services-watchdog-service
+time: 0
+message: this page has moved
+---

--- a/_redirects/hart-software-services.md
+++ b/_redirects/hart-software-services.md
@@ -1,0 +1,8 @@
+---
+layout: forward
+permalink: /redirects/hart-software-services
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/hart-software-services
+targetname: hart-software-services
+time: 0
+message: this page has moved
+---

--- a/_redirects/memory-hierarchy.md
+++ b/_redirects/memory-hierarchy.md
@@ -1,0 +1,8 @@
+---
+layout: forward
+permalink: /redirects/memory-hierarchy
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/memory-hierarchy
+targetname: memory-hierarchy
+time: 0
+message: this page has moved
+---

--- a/_redirects/releases-hart-software-services.md
+++ b/_redirects/releases-hart-software-services.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/releases-hart-software-services
+target: https://github.com/polarfire-soc/hart-software-services/releases
+targetname: releases-hart-software-services
+targettitle: taking you to releases-hart-software-services
+time: 0
+message: this page has moved
+---

--- a/_redirects/releases-icicle-kit-reference-design.md
+++ b/_redirects/releases-icicle-kit-reference-design.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/releases-icicle-kit-reference-design
+target: https://github.com/polarfire-soc/icicle-kit-reference-design/releases
+targetname: releases-icicle-kit-reference-design
+targettitle: taking you to releases-icicle-kit-reference-design
+time: 0
+message: this page has moved
+---

--- a/_redirects/releases-meta-polarfire-soc-yocto-bsp.md
+++ b/_redirects/releases-meta-polarfire-soc-yocto-bsp.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/releases-meta-polarfire-soc-yocto-bsp
+target: https://github.com/polarfire-soc/meta-polarfire-soc-yocto-bsp/releases
+targetname: releases-meta-polarfire-soc-yocto-bsp
+targettitle: taking you to releases-meta-polarfire-soc-yocto-bsp
+time: 0
+message: this page has moved
+---

--- a/_redirects/releases-platform.md
+++ b/_redirects/releases-platform.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/releases-platform
+target: https://github.com/polarfire-soc/platform/releases
+targetname: releases-platform
+targettitle: taking you to releases-platform
+time: 0
+message: this page has moved
+---

--- a/_redirects/releases-polarfire-soc-bare-metal-examples.md
+++ b/_redirects/releases-polarfire-soc-bare-metal-examples.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/releases-polarfire-soc-bare-metal-examples
+target: https://github.com/polarfire-soc/polarfire-soc-bare-metal-examples/releases
+targetname: releases-polarfire-soc-bare-metal-examples
+targettitle: taking you to releases-polarfire-soc-bare-metal-examples
+time: 0
+message: this page has moved
+---

--- a/_redirects/releases-polarfire-soc-bare-metal-library.md
+++ b/_redirects/releases-polarfire-soc-bare-metal-library.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/releases-polarfire-soc-bare-metal-library
+target: https://github.com/polarfire-soc/polarfire-soc-bare-metal-library/releases
+targetname: releases-polarfire-soc-bare-metal-library
+targettitle: taking you to releases-polarfire-soc-bare-metal-library
+time: 0
+message: this page has moved
+---

--- a/_redirects/releases-polarfire-soc-buildroot-sdk.md
+++ b/_redirects/releases-polarfire-soc-buildroot-sdk.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/releases-polarfire-soc-buildroot-sdk
+target: https://github.com/polarfire-soc/polarfire-soc-buildroot-sdk/releases
+targetname: releases-polarfire-soc-buildroot-sdk
+targettitle: taking you to releases-polarfire-soc-buildroot-sdk
+time: 0
+message: this page has moved
+---

--- a/_redirects/releases-polarfire-soc-documentation.md
+++ b/_redirects/releases-polarfire-soc-documentation.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/releases-polarfire-soc-documentation
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/releases
+targetname: releases-polarfire-soc-documentation
+targettitle: taking you to releases-polarfire-soc-documentation
+time: 0
+message: this page has moved
+---

--- a/_redirects/repo-apps.md
+++ b/_redirects/repo-apps.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-apps
+target: https://github.com/polarfire-soc/apps
+targetname: repo-apps
+targettitle: taking you to repo-apps
+time: 0
+message: this page has moved
+---

--- a/_redirects/repo-hart-software-services.md
+++ b/_redirects/repo-hart-software-services.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-hart-software-services
+target: https://github.com/polarfire-soc/hart-software-services
+targetname: repo-hart-software-services
+targettitle: taking you to repo-hart-software-services
+time: 0
+message: this page has moved
+---

--- a/_redirects/repo-icicle-kit-minimal-bring-up-design-bitstream-builder.md
+++ b/_redirects/repo-icicle-kit-minimal-bring-up-design-bitstream-builder.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-icicle-kit-minimal-bring-up-design-bitstream-builder
+target: https://github.com/polarfire-soc/icicle-kit-minimal-bring-up-design-bitstream-builder
+targetname: repo-icicle-kit-minimal-bring-up-design-bitstream-builder
+targettitle: taking you to repo-icicle-kit-minimal-bring-up-design-bitstream-builder
+time: 0
+message: this page has moved
+---

--- a/_redirects/repo-icicle-kit-minimal-bring-up-design-hdl-src.md
+++ b/_redirects/repo-icicle-kit-minimal-bring-up-design-hdl-src.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-icicle-kit-minimal-bring-up-design-hdl-src
+target: https://github.com/polarfire-soc/icicle-kit-minimal-bring-up-design-hdl-src
+targetname: repo-icicle-kit-minimal-bring-up-design-hdl-src
+targettitle: taking you to repo-icicle-kit-minimal-bring-up-design-hdl-src
+time: 0
+message: this page has moved
+---

--- a/_redirects/repo-icicle-kit-reference-design.md
+++ b/_redirects/repo-icicle-kit-reference-design.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-icicle-kit-reference-design
+target: https://github.com/polarfire-soc/icicle-kit-reference-design
+targetname: repo-icicle-kit-reference-design
+targettitle: taking you to repo-icicle-kit-reference-design
+time: 0
+message: this page has moved
+---

--- a/_redirects/repo-linux.md
+++ b/_redirects/repo-linux.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-linux
+target: https://github.com/polarfire-soc/linux
+targetname: repo-polarfire-soc-linux
+targettitle: taking you to repo-polarfire-soc-linux
+time: 0
+message: this page has moved
+---

--- a/_redirects/repo-meta-polarfire-soc-yocto-bsp.md
+++ b/_redirects/repo-meta-polarfire-soc-yocto-bsp.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-meta-polarfire-soc-yocto-bsp
+target: https://github.com/polarfire-soc/meta-polarfire-soc-yocto-bsp
+targetname: repo-meta-polarfire-soc-yocto-bsp
+targettitle: taking you to repo-meta-polarfire-soc-yocto-bsp
+time: 0
+message: this page has moved
+---

--- a/_redirects/repo-platform.md
+++ b/_redirects/repo-platform.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-platform
+target: https://github.com/polarfire-soc/platform
+targetname: repo-platform
+targettitle: taking you to repo-platform
+time: 0
+message: this page has moved
+---

--- a/_redirects/repo-polarfire-soc-amp-examples.md
+++ b/_redirects/repo-polarfire-soc-amp-examples.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-polarfire-soc-amp-examples
+target: https://github.com/polarfire-soc/polarfire-soc-amp-examples
+targetname: repo-polarfire-soc-amp-examples
+targettitle: taking you to repo-polarfire-soc-amp-examples
+time: 0
+message: this page has moved
+---

--- a/_redirects/repo-polarfire-soc-bare-metal-examples.md
+++ b/_redirects/repo-polarfire-soc-bare-metal-examples.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-polarfire-soc-bare-metal-examples
+target: https://github.com/polarfire-soc/polarfire-soc-bare-metal-examples
+targetname: repo-polarfire-soc-bare-metal-examples
+targettitle: taking you to repo-polarfire-soc-bare-metal-examples
+time: 0
+message: this page has moved
+---

--- a/_redirects/repo-polarfire-soc-bare-metal-library.md
+++ b/_redirects/repo-polarfire-soc-bare-metal-library.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-polarfire-soc-bare-metal-library
+target: https://github.com/polarfire-soc/polarfire-soc-bare-metal-library
+targetname: repo-polarfire-soc-bare-metal-library
+targettitle: taking you to repo-polarfire-soc-bare-metal-library
+time: 0
+message: this page has moved
+---

--- a/_redirects/repo-polarfire-soc-buildroot-sdk.md
+++ b/_redirects/repo-polarfire-soc-buildroot-sdk.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-polarfire-soc-buildroot-sdk
+target: https://github.com/polarfire-soc/polarfire-soc-buildroot-sdk
+targetname: repo-polarfire-soc-buildroot-sdk
+targettitle: taking you to repo-polarfire-soc-buildroot-sdk
+time: 0
+message: this page has moved
+---

--- a/_redirects/repo-polarfire-soc-configuration-generator.md
+++ b/_redirects/repo-polarfire-soc-configuration-generator.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-polarfire-soc-configuration-generator
+target: https://github.com/polarfire-soc/polarfire-soc-configuration-generator
+targetname: repo-polarfire-soc-configuration-generator
+targettitle: taking you to repo-polarfire-soc-configuration-generator
+time: 0
+message: this page has moved
+---

--- a/_redirects/repo-polarfire-soc-documentation.md
+++ b/_redirects/repo-polarfire-soc-documentation.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-polarfire-soc-documentation
+target: https://github.com/polarfire-soc/polarfire-soc-documentation
+targetname: repo-polarfire-soc-documentation
+targettitle: taking you to repo-polarfire-soc-documentation
+time: 0
+message: this page has moved
+---

--- a/_redirects/repo-polarfire-soc-linux-examples.md
+++ b/_redirects/repo-polarfire-soc-linux-examples.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-polarfire-soc-linux-examples
+target: https://github.com/polarfire-soc/polarfire-soc-linux-examples
+targetname: repo-polarfire-soc-linux-examples
+targettitle: taking you to repo-polarfire-soc-linux-examples
+time: 0
+message: this page has moved
+---

--- a/_redirects/repo-polarfire-soc-zephyr-applications.md
+++ b/_redirects/repo-polarfire-soc-zephyr-applications.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-polarfire-soc-zephyr-applications
+target: https://github.com/polarfire-soc/polarfire-soc-zephyr-applications
+targetname: repo-polarfire-soc-zephyr-applications
+targettitle: taking you to repo-polarfire-soc-zephyr-applications
+time: 0
+message: this page has moved
+---

--- a/_redirects/repo-rtems.md
+++ b/_redirects/repo-rtems.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-rtems
+target: https://github.com/polarfire-soc/rtems
+targetname: repo-rtems
+targettitle: taking you to repo-rtems
+time: 0
+message: this page has moved
+---

--- a/_redirects/repo-zephyr-archive-Dec-2021.md
+++ b/_redirects/repo-zephyr-archive-Dec-2021.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-zephyr-archive-Dec-2021
+target: https://github.com/polarfire-soc/zephyr-archive-Dec-2021
+targetname: repo-zephyr-archive-Dec-2021
+targettitle: taking you to repo-zephyr-archive-Dec-2021
+time: 0
+message: this page has moved
+---

--- a/_redirects/repo-zephyr-mpfs-hal_microchip.md
+++ b/_redirects/repo-zephyr-mpfs-hal_microchip.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-zephyr-mpfs-hal_microchip
+target: https://github.com/polarfire-soc/zephyr-mpfs-hal_microchip
+targetname: repo-zephyr-mpfs-hal_microchip
+targettitle: taking you to repo-zephyr-mpfs-hal_microchip
+time: 0
+message: this page has moved
+---

--- a/_redirects/repo-zephyr.md
+++ b/_redirects/repo-zephyr.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-zephyr
+target: https://github.com/polarfire-soc/zephyr
+targetname: repo-zephyr
+targettitle: taking you to repo-zephyr
+time: 0
+message: this page has moved
+---

--- a/_redirects/software-development.md
+++ b/_redirects/software-development.md
@@ -1,0 +1,8 @@
+---
+layout: forward
+permalink: /redirects/software-development
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/software-development
+targetname: software-development
+time: 0
+message: this page has moved
+---

--- a/_redirects/tool-hss-payload-generator.md
+++ b/_redirects/tool-hss-payload-generator.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/tool-hss-payload-generator
+target: https://github.com/polarfire-soc/hart-software-services/tree/master/tools/hss-payload-generator
+targetname: tool-hss-payload-generator
+targettitle: taking you to tool-hss-payload-generator
+time: 0
+message: this page has moved
+---


### PR DESCRIPTION
These redirects are for folders contained in the MPFS documentation repository and not individual documents