### PR TITLE
Redirect updates: change links for boards reorg

### DIFF
--- a/_redirects/boards-mpfs-icicle-kit-es-booting-from-qspi.md
+++ b/_redirects/boards-mpfs-icicle-kit-es-booting-from-qspi.md
@@ -1,9 +1,9 @@
 ---
 layout: forward
 permalink: /redirects/boards-mpfs-icicle-kit-es-booting-from-qspi
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-icicle-kit-es/booting-from-qspi
-targetname: boards-mpfs-icicle-kit-es-booting-from-qspi
-targettitle: taking you to boards-mpfs-icicle-kit-es-booting-from-qspi
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-generic/booting-from-qspi/booting-from-qspi.md
+targetname: boards-mpfs-generic-booting-from-qspi
+targettitle: taking you to boards-mpfs-generic-booting-from-qspi
 time: 0
 message: this page has moved
 ---

--- a/_redirects/boards-mpfs-icicle-kit-es-icicle-kit-sw-developer-guide.md
+++ b/_redirects/boards-mpfs-icicle-kit-es-icicle-kit-sw-developer-guide.md
@@ -1,9 +1,9 @@
 ---
 layout: forward
 permalink: /redirects/boards-mpfs-icicle-kit-es-icicle-kit-sw-developer-guide
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-icicle-kit-es/icicle-kit-sw-developer-guide
-targetname: boards-mpfs-icicle-kit-es-icicle-kit-sw-developer-guide
-targettitle: taking you to boards-mpfs-icicle-kit-es-icicle-kit-sw-developer-guide
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-icicle-kit-es/icicle-kit-user-guide/icicle-kit-user-guide.md
+targetname: boards-mpfs-icicle-kit-es-icicle-kit-user-guide
+targettitle: taking you to boards-mpfs-icicle-kit-es-icicle-kit-user-guide
 time: 0
 message: this page has moved
 ---

--- a/_redirects/boards-mpfs-icicle-kit-es-programming-spi-flash-via-libero.md
+++ b/_redirects/boards-mpfs-icicle-kit-es-programming-spi-flash-via-libero.md
@@ -1,9 +1,9 @@
 ---
 layout: forward
 permalink: /redirects/boards-mpfs-icicle-kit-es-programming-spi-flash-via-libero
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-icicle-kit-es/programming-spi-flash-via-libero
-targetname: boards-mpfs-icicle-kit-es-programming-spi-flash-via-libero
-targettitle: taking you to boards-mpfs-icicle-kit-es-programming-spi-flash-via-libero
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-generic/programming-the-spi-flash-on-a-polarfire-soc-board-and-booting-via-hss/programming-the-spi-flash-on-a-polarfire-soc-board-and-booting-via-hss.md
+targetname: boards-mpfs-generic-programming-the-spi-flash-on-a-polarfire-soc-board-and-booting-via-hss
+targettitle: taking you to boards-mpfs-generic-programming-the-spi-flash-on-a-polarfire-soc-board-and-booting-via-hss
 time: 0
 message: this page has moved
 ---

--- a/_redirects/boards-mpfs-icicle-kit-es-updating-icicle-kit.md
+++ b/_redirects/boards-mpfs-icicle-kit-es-updating-icicle-kit.md
@@ -1,9 +1,9 @@
 ---
 layout: forward
 permalink: /redirects/boards-mpfs-icicle-kit-es-updating-icicle-kit
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-icicle-kit-es/updating-icicle-kit
-targetname: boards-mpfs-icicle-kit-es-updating-icicle-kit
-targettitle: taking you to boards-mpfs-icicle-kit-es-updating-icicle-kit
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-icicle-kit-es/icicle-kit-user-guide/icicle-kit-user-guide.md
+targetname: boards-mpfs-icicle-kit-es-icicle-kit-user-guide
+targettitle: taking you to boards-mpfs-icicle-kit-es-icicle-kit-user-guide
 time: 0
 message: this page has moved
 ---

--- a/_redirects/booting-from-qspi_booting-from-qspi.md
+++ b/_redirects/booting-from-qspi_booting-from-qspi.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/booting-from-qspi_booting-from-qspi
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/mpfs-icicle-kit-es/booting-from-qspi/booting-from-qspi.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/mpfs-generic/booting-from-qspi/booting-from-qspi.md
 targetname: booting-from-qspi_booting-from-qspi
 targettitle: taking you to booting-from-qspi_booting-from-qspi
 time: 0

--- a/_redirects/icicle-kit-sw-developer-guide_icicle-kit-sw-developer-guide.md
+++ b/_redirects/icicle-kit-sw-developer-guide_icicle-kit-sw-developer-guide.md
@@ -1,9 +1,9 @@
 ---
 layout: forward
 permalink: /redirects/icicle-kit-sw-developer-guide_icicle-kit-sw-developer-guide
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/mpfs-icicle-kit-es/icicle-kit-sw-developer-guide/icicle-kit-sw-developer-guide.md
-targetname: icicle-kit-sw-developer-guide_icicle-kit-sw-developer-guide
-targettitle: taking you to icicle-kit-sw-developer-guide_icicle-kit-sw-developer-guide
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/mpfs-icicle-kit-es/icicle-kit-user-guide/icicle-kit-user-guide.md
+targetname: mpfs-icicle-kit-es-icicle-kit-user-guide-icicle-kit-user-guide.md
+targettitle: taking you to mpfs-icicle-kit-es-icicle-kit-user-guide-icicle-kit-user-guide.md
 time: 0
 message: this page has moved
 ---

--- a/_redirects/programming-spi-flash-via-libero_programming-spi-flash-via-libero.md
+++ b/_redirects/programming-spi-flash-via-libero_programming-spi-flash-via-libero.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/programming-spi-flash-via-libero_programming-spi-flash-via-libero
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/mpfs-icicle-kit-es/programming-spi-flash-via-libero/programming-spi-flash-via-libero.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/mpfs-generic/programming-spi-flash-via-libero/programming-spi-flash-via-libero.md
 targetname: programming-spi-flash-via-libero_programming-spi-flash-via-libero
 targettitle: taking you to programming-spi-flash-via-libero_programming-spi-flash-via-libero
 time: 0

--- a/_redirects/updating-icicle-kit_updating-icicle-kit-design-and-linux.md
+++ b/_redirects/updating-icicle-kit_updating-icicle-kit-design-and-linux.md
@@ -1,9 +1,9 @@
 ---
 layout: forward
 permalink: /redirects/updating-icicle-kit_updating-icicle-kit-design-and-linux
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/mpfs-icicle-kit-es/updating-icicle-kit/updating-icicle-kit-design-and-linux.md
-targetname: updating-icicle-kit_updating-icicle-kit-design-and-linux
-targettitle: taking you to updating-icicle-kit_updating-icicle-kit-design-and-linux
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/mpfs-icicle-kit-es/icicle-kit-user-guide/icicle-kit-user-guide.md
+targetname: boards-mpfs-icicle-kit-es-icicle-kit-user-guide
+targettitle: boards-mpfs-icicle-kit-es-icicle-kit-user-guide
 time: 0
 message: this page has moved
 ---


### PR DESCRIPTION
Updated redirect links to point to the new documentation that will be available after re-organizing the boards directory in PolarFire SoC Documentation.

**Do not merge to main until the 2022.09 release of the PolarFire SoC Documentation repository**