### PR TITLE
redirects: add redirect links for buildroot external

### DIFF
--- a/_redirects/repo-microchip-buildroot-external.md
+++ b/_redirects/repo-microchip-buildroot-external.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-microchip-buildroot-external
+target: https://github.com/linux4microchip/buildroot-external-microchip
+targetname: repo-microchip-buildroot-external
+targettitle: taking you to repo-microchip-buildroot-external
+time: 0
+message: this page has moved
+---


### PR DESCRIPTION
Add redirect to the Microchip buildroot external repository

Signed-off-by: Valentina Fernandez <valentina.fernandezalanis@microchip.com>