### PR TITLE
Add debug from scratchpad document redirect

### DIFF
--- a/_redirects/polarfire-soc/documentation/How-To/debug-from-scratchpad.md
+++ b/_redirects/polarfire-soc/documentation/How-To/debug-from-scratchpad.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/How-To/debug-from-scratchpad
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/fundamentals/debug-from-scratchpad/debug-from-scratchpad.md
+targetname: debug-from-scratchpad
+targettitle: taking you to debug-from-scratchpad
+time: 0
+message: this page has moved
+---

--- a/_redirects/polarfire-soc/documentation/How-To/debug-from-scratchpad.md
+++ b/_redirects/polarfire-soc/documentation/How-To/debug-from-scratchpad.md
@@ -1,9 +1,0 @@
----
-layout: forward
-permalink: /redirects/fundamentals/debug-from-scratchpad
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/fundamentals/debug-from-scratchpad/debug-from-scratchpad.md
-targetname: debug-from-scratchpad
-targettitle: taking you to debug-from-scratchpad
-time: 0
-message: this page has moved
----

--- a/_redirects/polarfire-soc/documentation/How-To/debug-from-scratchpad.md
+++ b/_redirects/polarfire-soc/documentation/How-To/debug-from-scratchpad.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/fundamentals/debug-from-scratchpad
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/fundamentals/debug-from-scratchpad/debug-from-scratchpad.md
+targetname: debug-from-scratchpad
+targettitle: taking you to debug-from-scratchpad
+time: 0
+message: this page has moved
+---


### PR DESCRIPTION
There isn't a redirect for this document at present, adding one