### PR TITLE
Revert "Update redirects for PolarFire SoC documentation reorg"

### DIFF
--- a/_redirects/polarfire-soc/documentation/Applications-and-Demos/amp/asymmetric-multiprocessing.md
+++ b/_redirects/polarfire-soc/documentation/Applications-and-Demos/amp/asymmetric-multiprocessing.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/asymmetric-multiprocessing
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/applications-and-demos/asymmetric-multiprocessing
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/asymmetric-multiprocessing
 targetname: asymmetric-multiprocessing
 targettitle: taking you to asymmetric-multiprocessing
 time: 0

--- a/_redirects/polarfire-soc/documentation/Applications-and-Demos/amp/asymmetric-multiprocessing_amp.md
+++ b/_redirects/polarfire-soc/documentation/Applications-and-Demos/amp/asymmetric-multiprocessing_amp.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/asymmetric-multiprocessing_amp
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/applications-and-demos/asymmetric-multiprocessing/amp.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/asymmetric-multiprocessing/amp.md
 targetname: asymmetric-multiprocessing_amp
 targettitle: taking you to asymmetric-multiprocessing_amp
 time: 0

--- a/_redirects/polarfire-soc/documentation/Applications-and-Demos/amp/asymmetric-multiprocessing_ihc.md
+++ b/_redirects/polarfire-soc/documentation/Applications-and-Demos/amp/asymmetric-multiprocessing_ihc.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/asymmetric-multiprocessing_ihc
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/applications-and-demos/asymmetric-multiprocessing/ihc.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/asymmetric-multiprocessing/ihc.md
 targetname: asymmetric-multiprocessing_ihc
 targettitle: taking you to asymmetric-multiprocessing_ihc
 time: 0

--- a/_redirects/polarfire-soc/documentation/Applications-and-Demos/amp/asymmetric-multiprocessing_remoteproc.md
+++ b/_redirects/polarfire-soc/documentation/Applications-and-Demos/amp/asymmetric-multiprocessing_remoteproc.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/asymmetric-multiprocessing_remoteproc
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/applications-and-demos/asymmetric-multiprocessing/remoteproc.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/asymmetric-multiprocessing/remoteproc.md
 targetname: asymmetric-multiprocessing_remoteproc
 targettitle: taking you to asymmetric-multiprocessing_remoteproc
 time: 0

--- a/_redirects/polarfire-soc/documentation/Applications-and-Demos/amp/asymmetric-multiprocessing_rpmsg-client-drivers.md
+++ b/_redirects/polarfire-soc/documentation/Applications-and-Demos/amp/asymmetric-multiprocessing_rpmsg-client-drivers.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/asymmetric-multiprocessing_rpmsg-client-drivers
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/applications-and-demos/asymmetric-multiprocessing/rpmsg-client-drivers.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/asymmetric-multiprocessing/rpmsg-client-drivers.md
 targetname: asymmetric-multiprocessing_rpmsg-client-drivers
 targettitle: taking you to asymmetric-multiprocessing_rpmsg-client-drivers
 time: 0

--- a/_redirects/polarfire-soc/documentation/Applications-and-Demos/amp/asymmetric-multiprocessing_rpmsg.md
+++ b/_redirects/polarfire-soc/documentation/Applications-and-Demos/amp/asymmetric-multiprocessing_rpmsg.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/asymmetric-multiprocessing_rpmsg
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/applications-and-demos/asymmetric-multiprocessing/rpmsg.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/asymmetric-multiprocessing/rpmsg.md
 targetname: asymmetric-multiprocessing_rpmsg
 targettitle: taking you to asymmetric-multiprocessing_rpmsg
 time: 0

--- a/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-guides-mpfs-dma-benchmarking.md
+++ b/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-guides-mpfs-dma-benchmarking.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/demo-guides_mpfs-dma-benchmarking
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/knowledge-base/mpfs-dma-benchmarking.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/demo-guides/mpfs-dma-benchmarking.md
 targetname: demo-guides_mpfs-dma-benchmarking
 targettitle: demo-guides_mpfs-dma-benchmarking
 time: 0

--- a/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-guides-mpfs-sev-h264-demo.md
+++ b/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-guides-mpfs-sev-h264-demo.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/demo-guides-mpfs-sev-h264-demo
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/applications-and-demos/mpfs-sev-h264-demo.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/demo-guides/mpfs-sev-h264-demo.md
 targetname: demo-guides-mpfs-sev-h264-demo
 targettitle: taking you to demo-guides-mpfs-sev-h264-demo
 time: 0

--- a/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-guides.md
+++ b/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-guides.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/demo-guides
-target: ttps://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/applications-and-demos
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/demo-guides
 targetname: demo-guides
 targettitle: taking you to demo-guides
 time: 0

--- a/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-guides_mpfs-axi4-stream-demo.md
+++ b/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-guides_mpfs-axi4-stream-demo.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/demo-guides_mpfs-axi4-stream-demo
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/applications-and-demos/mpfs-axi4-stream-demo.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/demo-guides/mpfs-axi4-stream-demo.md
 targetname: demo-guides_mpfs-axi4-stream-demo
 targettitle: taking you to demo-guides_mpfs-axi4-stream-demo
 time: 0

--- a/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-guides_mpfs-pmp-demo.md
+++ b/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-guides_mpfs-pmp-demo.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/demo-guides_mpfs-pmp-demo
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/applications-and-demos/mpfs-pmp-demo.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/demo-guides/mpfs-pmp-demo.md
 targetname: demo-guides_mpfs-pmp-demo
 targettitle: taking you to demo-guides_mpfs-pmp-demo
 time: 0

--- a/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-mpfs-dma-benchmarking.md
+++ b/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-mpfs-dma-benchmarking.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/demo-mpfs-dma-benchmarking
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/knowledge-base/mpfs-dma-benchmarking.md
+target: https://github.com/polarfire-soc/polarfire-soc-bare-metal-examples/tree/main/applications/benchmarks/dma_benchmarking/mpfs-dma-benchmarking/
 targetname: demo-mpfs-dma-benchmarking
 targettitle: taking you to demo-mpfs-dma-benchmarking
 time: 0

--- a/_redirects/polarfire-soc/documentation/Bare-Metal-Embedded-Software/bare-metal-project-structure.md
+++ b/_redirects/polarfire-soc/documentation/Bare-Metal-Embedded-Software/bare-metal-project-structure.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/bare-metal-project-structure
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/bare-metal-embedded-software/bare-metal-software-project-structure.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/bare-metal-project-structure
 targetname: bare-metal-project-structure
 targettitle: taking you to bare-metal-project-structure
 time: 0

--- a/_redirects/polarfire-soc/documentation/Bare-Metal-Embedded-Software/bare-metal-project-structure_bare-metal-software-project-structure.md
+++ b/_redirects/polarfire-soc/documentation/Bare-Metal-Embedded-Software/bare-metal-project-structure_bare-metal-software-project-structure.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/bare-metal-project-structure_bare-metal-software-project-structure
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/bare-metal-embedded-software/bare-metal-software-project-structure.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/bare-metal-project-structure/bare-metal-software-project-structure.md
 targetname: bare-metal-project-structure_bare-metal-software-project-structure
 targettitle: taking you to bare-metal-project-structure_bare-metal-software-project-structure
 time: 0

--- a/_redirects/polarfire-soc/documentation/HSS-and-U-Boot/hart-software-services-secure-boot.md
+++ b/_redirects/polarfire-soc/documentation/HSS-and-U-Boot/hart-software-services-secure-boot.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/hart-software-services-secure-boot
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/hss-and-u-boot/secure-boot.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/hart-software-services/secure-boot
 targetname: hart-software-services-secure-boot
 time: 0
 message: this page has moved

--- a/_redirects/polarfire-soc/documentation/HSS-and-U-Boot/hart-software-services-watchdog-service.md
+++ b/_redirects/polarfire-soc/documentation/HSS-and-U-Boot/hart-software-services-watchdog-service.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/hart-software-services-watchdog-service
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/hss-and-u-boot/watchdog-service.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/hart-software-services/watchdog-service
 targetname: hart-software-services-watchdog-service
 time: 0
 message: this page has moved

--- a/_redirects/polarfire-soc/documentation/HSS-and-U-Boot/hart-software-services.md
+++ b/_redirects/polarfire-soc/documentation/HSS-and-U-Boot/hart-software-services.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/hart-software-services
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/hss-and-u-boot
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/hart-software-services
 targetname: hart-software-services
 time: 0
 message: this page has moved

--- a/_redirects/polarfire-soc/documentation/HSS-and-U-Boot/secure-boot_secure-boot.md
+++ b/_redirects/polarfire-soc/documentation/HSS-and-U-Boot/secure-boot_secure-boot.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/secure-boot_secure-boot
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/hss-and-u-boot/secure-boot.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/hart-software-services/secure-boot/secure-boot.md
 targetname: secure-boot_secure-boot
 targettitle: taking you to secure-boot_secure-boot
 time: 0

--- a/_redirects/polarfire-soc/documentation/HSS-and-U-Boot/software-development_hss-payloads.md
+++ b/_redirects/polarfire-soc/documentation/HSS-and-U-Boot/software-development_hss-payloads.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/software-development_hss-payloads
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/hss-and-u-boot/hss-payloads.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/software-development/hss-payloads.md
 targetname: software-development_hss-payloads
 targettitle: taking you to software-development_hss-payloads
 time: 0

--- a/_redirects/polarfire-soc/documentation/HSS-and-U-Boot/watchdog-service_watchdog-service.md
+++ b/_redirects/polarfire-soc/documentation/HSS-and-U-Boot/watchdog-service_watchdog-service.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/watchdog-service_watchdog-service
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/hss-and-u-boot/watchdog-service.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/hart-software-services/watchdog-service/watchdog-service.md
 targetname: watchdog-service_watchdog-service
 targettitle: taking you to watchdog-service_watchdog-service
 time: 0

--- a/_redirects/polarfire-soc/documentation/How-To/boards-mpfs-icicle-kit-es-booting-from-qspi.md
+++ b/_redirects/polarfire-soc/documentation/How-To/boards-mpfs-icicle-kit-es-booting-from-qspi.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/boards-mpfs-icicle-kit-es-booting-from-qspi
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/how-to/booting-from-qspi.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-generic/booting-from-qspi/booting-from-qspi.md
 targetname: boards-mpfs-generic-booting-from-qspi
 targettitle: taking you to boards-mpfs-generic-booting-from-qspi
 time: 0

--- a/_redirects/polarfire-soc/documentation/How-To/boards-mpfs-icicle-kit-es-programming-spi-flash-via-libero.md
+++ b/_redirects/polarfire-soc/documentation/How-To/boards-mpfs-icicle-kit-es-programming-spi-flash-via-libero.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/boards-mpfs-icicle-kit-es-programming-spi-flash-via-libero
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/how-to/programming-the-spi-flash-on-a-polarfire-soc-board-and-booting-via-hss.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-generic/programming-the-spi-flash-on-a-polarfire-soc-board-and-booting-via-hss/programming-the-spi-flash-on-a-polarfire-soc-board-and-booting-via-hss.md
 targetname: boards-mpfs-generic-programming-the-spi-flash-on-a-polarfire-soc-board-and-booting-via-hss
 targettitle: taking you to boards-mpfs-generic-programming-the-spi-flash-on-a-polarfire-soc-board-and-booting-via-hss
 time: 0

--- a/_redirects/polarfire-soc/documentation/How-To/booting-from-qspi_booting-from-qspi.md
+++ b/_redirects/polarfire-soc/documentation/How-To/booting-from-qspi_booting-from-qspi.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/booting-from-qspi_booting-from-qspi
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/how-to/booting-from-qspi.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/mpfs-generic/booting-from-qspi/booting-from-qspi.md
 targetname: booting-from-qspi_booting-from-qspi
 targettitle: taking you to booting-from-qspi_booting-from-qspi
 time: 0

--- a/_redirects/polarfire-soc/documentation/How-To/debug-from-scratchpad.md
+++ b/_redirects/polarfire-soc/documentation/How-To/debug-from-scratchpad.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/How-To/debug-from-scratchpad
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/how-to/debug-from-scratchpad.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/fundamentals/debug-from-scratchpad/debug-from-scratchpad.md
 targetname: debug-from-scratchpad
 targettitle: taking you to debug-from-scratchpad
 time: 0

--- a/_redirects/polarfire-soc/documentation/How-To/programming-spi-flash-via-libero_programming-spi-flash-via-libero.md
+++ b/_redirects/polarfire-soc/documentation/How-To/programming-spi-flash-via-libero_programming-spi-flash-via-libero.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/programming-spi-flash-via-libero_programming-spi-flash-via-libero
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/how-to/programming-the-spi-flash-on-a-polarfire-soc-board-and-booting-via-hss.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/mpfs-generic/programming-spi-flash-via-libero/programming-spi-flash-via-libero.md
 targetname: programming-spi-flash-via-libero_programming-spi-flash-via-libero
 targettitle: taking you to programming-spi-flash-via-libero_programming-spi-flash-via-libero
 time: 0

--- a/_redirects/polarfire-soc/documentation/How-To/software-development_multiprocessor-debugging.md
+++ b/_redirects/polarfire-soc/documentation/How-To/software-development_multiprocessor-debugging.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/software-development_multiprocessor-debugging
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/how-to/multiprocessor-debugging.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/software-development/multiprocessor-debugging.md
 targetname: software-development_multiprocessor-debugging
 targettitle: taking you to software-development_multiprocessor-debugging
 time: 0

--- a/_redirects/polarfire-soc/documentation/Knowledge-Base/boot-modes/boot-mode-1_boot-mode-1-fundamentals.md
+++ b/_redirects/polarfire-soc/documentation/Knowledge-Base/boot-modes/boot-mode-1_boot-mode-1-fundamentals.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/boot-mode-1_boot-mode-1-fundamentals
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/knowledge-base/boot-modes/boot-mode-1-fundamentals.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/fundamentals/boot-modes/boot-mode-1/boot-mode-1-fundamentals.md
 targetname: boot-mode-1_boot-mode-1-fundamentals
 targettitle: taking you to boot-mode-1_boot-mode-1-fundamentals
 time: 0

--- a/_redirects/polarfire-soc/documentation/Knowledge-Base/boot-modes/boot-mode-2_boot-mode-2-fundamentals.md
+++ b/_redirects/polarfire-soc/documentation/Knowledge-Base/boot-modes/boot-mode-2_boot-mode-2-fundamentals.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/boot-mode-2_boot-mode-2-fundamentals
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/knowledge-base/boot-modes/boot-mode-2-fundamentals.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/fundamentals/boot-modes/boot-mode-2/boot-mode-2-fundamentals.md
 targetname: boot-mode-2_boot-mode-2-fundamentals
 targettitle: taking you to boot-mode-2_boot-mode-2-fundamentals
 time: 0

--- a/_redirects/polarfire-soc/documentation/Knowledge-Base/boot-modes/boot-mode-3_boot-mode-3-fundamentals.md
+++ b/_redirects/polarfire-soc/documentation/Knowledge-Base/boot-modes/boot-mode-3_boot-mode-3-fundamentals.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/boot-mode-3_boot-mode-3-fundamentals
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/knowledge-base/boot-modes/boot-mode-3-fundamentals.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/fundamentals/boot-modes/boot-mode-3/boot-mode-3-fundamentals.md
 targetname: boot-mode-3_boot-mode-3-fundamentals
 targettitle: taking you to boot-mode-3_boot-mode-3-fundamentals
 time: 0

--- a/_redirects/polarfire-soc/documentation/Knowledge-Base/boot-modes/boot-modes_boot-modes-fundamentals.md
+++ b/_redirects/polarfire-soc/documentation/Knowledge-Base/boot-modes/boot-modes_boot-modes-fundamentals.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/boot-modes_boot-modes-fundamentals
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/knowledge-base/boot-modes/boot-mode-0-fundamentals.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/fundamentals/boot-modes/boot-modes-fundamentals.md
 targetname: boot-modes_boot-modes-fundamentals
 targettitle: taking you to boot-modes_boot-modes-fundamentals
 time: 0

--- a/_redirects/polarfire-soc/documentation/Knowledge-Base/boot-modes/fundamentals-boot-modes.md
+++ b/_redirects/polarfire-soc/documentation/Knowledge-Base/boot-modes/fundamentals-boot-modes.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/fundamentals-boot-modes
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/knowledge-base/boot-modes/boot-modes-fundamentals.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/fundamentals/boot-modes
 targetname: fundamentals-boot-modes
 targettitle: taking you to fundamentals-boot-modes
 time: 0

--- a/_redirects/polarfire-soc/documentation/Knowledge-Base/fundamentals-pcie.md
+++ b/_redirects/polarfire-soc/documentation/Knowledge-Base/fundamentals-pcie.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/fundamentals-pcie
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/knowledge-base
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/fundamentals/pcie
 targetname: fundamentals-pcie
 targettitle: taking you to fundamentals-pcie
 time: 0

--- a/_redirects/polarfire-soc/documentation/Knowledge-Base/fundamentals.md
+++ b/_redirects/polarfire-soc/documentation/Knowledge-Base/fundamentals.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/fundamentals
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/knowledge-base
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/fundamentals
 targetname: fundamentals
 targettitle: taking you to fundamentals
 time: 0

--- a/_redirects/polarfire-soc/documentation/Knowledge-Base/memory-hierarchy.md
+++ b/_redirects/polarfire-soc/documentation/Knowledge-Base/memory-hierarchy.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/memory-hierarchy
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/knowledge-base/mpfs-memory-hierarchy.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/memory-hierarchy
 targetname: memory-hierarchy
 time: 0
 message: this page has moved

--- a/_redirects/polarfire-soc/documentation/Knowledge-Base/memory-hierarchy_mpfs-memory-hierarchy.md
+++ b/_redirects/polarfire-soc/documentation/Knowledge-Base/memory-hierarchy_mpfs-memory-hierarchy.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/memory-hierarchy_mpfs-memory-hierarchy
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/knowledge-base/mpfs-memory-hierarchy.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/memory-hierarchy/mpfs-memory-hierarchy.md
 targetname: memory-hierarchy_mpfs-memory-hierarchy
 targettitle: taking you to memory-hierarchy_mpfs-memory-hierarchy
 time: 0

--- a/_redirects/polarfire-soc/documentation/Knowledge-Base/software-development.md
+++ b/_redirects/polarfire-soc/documentation/Knowledge-Base/software-development.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/software-development
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/knowledge-base/polarfire-soc-software-tool-flow.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/software-development
 targetname: software-development
 time: 0
 message: this page has moved

--- a/_redirects/polarfire-soc/documentation/Knowledge-Base/software-development_polarfire-soc-software-tool-flow.md
+++ b/_redirects/polarfire-soc/documentation/Knowledge-Base/software-development_polarfire-soc-software-tool-flow.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/software-development_polarfire-soc-software-tool-flow
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/knowledge-base/polarfire-soc-software-tool-flow.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/software-development/polarfire-soc-software-tool-flow.md
 targetname: software-development_polarfire-soc-software-tool-flow
 targettitle: taking you to software-development_polarfire-soc-software-tool-flow
 time: 0

--- a/_redirects/polarfire-soc/documentation/Linux-drivers-and-build-systems-for-PolarFire-SoC/pcie_mpfs-memory-configuration.md
+++ b/_redirects/polarfire-soc/documentation/Linux-drivers-and-build-systems-for-PolarFire-SoC/pcie_mpfs-memory-configuration.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/pcie_mpfs-memory-configuration
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/knowledge-base/mpfs-memory-configuration.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/fundamentals/pcie/mpfs-memory-configuration.md
 targetname: pcie_mpfs-memory-configuration
 targettitle: taking you to pcie_mpfs-memory-configuration
 time: 0

--- a/_redirects/polarfire-soc/documentation/Linux-drivers-and-build-systems-for-PolarFire-SoC/software-development_polarfire-soc-usb.md
+++ b/_redirects/polarfire-soc/documentation/Linux-drivers-and-build-systems-for-PolarFire-SoC/software-development_polarfire-soc-usb.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/software-development_polarfire-soc-usb
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/linux-drivers-and-build-systems/polarfire-soc-usb.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/software-development/polarfire-soc-usb.md
 targetname: software-development_polarfire-soc-usb
 targettitle: taking you to software-development_polarfire-soc-usb
 time: 0

--- a/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/boards-lc-mpfs-dev-kit.md
+++ b/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/boards-lc-mpfs-dev-kit.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/boards-lc-mpfs-dev-kit
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/reference-designs-fpga-and-development-kits/lc-mpfs-dev-kit-user-guide.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/lc-mpfs-dev-kit
 targetname: boards-lc-mpfs-dev-kit
 targettitle: taking you to boards-lc-mpfs-dev-kit
 time: 0

--- a/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/boards-mpfs-dev-kit.md
+++ b/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/boards-mpfs-dev-kit.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/boards-mpfs-dev-kit
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/reference-designs-fpga-and-development-kits/mpfs-dev-kit-user-guide.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-dev-kit
 targetname: boards-mpfs-dev-kit
 targettitle: taking you to boards-mpfs-dev-kit
 time: 0

--- a/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/boards-mpfs-generic-updating-mpfs-kit.md
+++ b/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/boards-mpfs-generic-updating-mpfs-kit.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/boards-mpfs-generic-updating-mpfs-kit
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/reference-designs-fpga-and-development-kits/updating-mpfs-kit.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-generic/updating-mpfs-kit/updating-mpfs-kit.md
 targetname: boards-mpfs-generic-updating-mpfs-kit
 targettitle: taking you to boards-mpfs-generic-updating-mpfs-kit
 time: 0

--- a/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/boards-mpfs-icicle-kit-es-icicle-kit-sw-developer-guide.md
+++ b/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/boards-mpfs-icicle-kit-es-icicle-kit-sw-developer-guide.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/boards-mpfs-icicle-kit-es-icicle-kit-sw-developer-guide
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/reference-designs-fpga-and-development-kits/icicle-kit-user-guide.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-icicle-kit-es/icicle-kit-user-guide/icicle-kit-user-guide.md
 targetname: boards-mpfs-icicle-kit-es-icicle-kit-user-guide
 targettitle: taking you to boards-mpfs-icicle-kit-es-icicle-kit-user-guide
 time: 0

--- a/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/boards-mpfs-icicle-kit-es-updating-icicle-kit.md
+++ b/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/boards-mpfs-icicle-kit-es-updating-icicle-kit.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/boards-mpfs-icicle-kit-es-updating-icicle-kit
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/reference-designs-fpga-and-development-kits/icicle-kit-user-guide.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-icicle-kit-es/icicle-kit-user-guide/icicle-kit-user-guide.md
 targetname: boards-mpfs-icicle-kit-es-icicle-kit-user-guide
 targettitle: taking you to boards-mpfs-icicle-kit-es-icicle-kit-user-guide
 time: 0

--- a/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/boards-mpfs-icicle-kit-es.md
+++ b/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/boards-mpfs-icicle-kit-es.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/boards-mpfs-icicle-kit-es
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/reference-designs-fpga-and-development-kits/icicle-kit-user-guide.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/boards/mpfs-icicle-kit-es
 targetname: boards-mpfs-icicle-kit-es
 targettitle: taking you to boards-mpfs-icicle-kit-es
 time: 0

--- a/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/boards-mpfs-sev-kit-sev-kit-user-guide.md
+++ b/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/boards-mpfs-sev-kit-sev-kit-user-guide.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/boards-mpfs-sev-kit-sev-kit-user-guide
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/reference-designs-fpga-and-development-kits/sev-kit-user-guide.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/mpfs-sev-kit-es/sev-kit-user-guide/sev-kit-user-guide.md
 targetname: boards-mpfs-sev-kit-sev-kit-user-guide
 targettitle: taking you to boards-mpfs-sev-kit-sev-kit-user-guide
 time: 0

--- a/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/boards.md
+++ b/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/boards.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/boards
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/reference-designs-fpga-and-development-kits/
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards
 targetname: boards
 targettitle: taking you to boards
 time: 0

--- a/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/icicle-kit-sw-developer-guide_icicle-kit-sw-developer-guide.md
+++ b/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/icicle-kit-sw-developer-guide_icicle-kit-sw-developer-guide.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/icicle-kit-sw-developer-guide_icicle-kit-sw-developer-guide
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/reference-designs-fpga-and-development-kits/icicle-kit-user-guide.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/mpfs-icicle-kit-es/icicle-kit-user-guide/icicle-kit-user-guide.md
 targetname: mpfs-icicle-kit-es-icicle-kit-user-guide-icicle-kit-user-guide.md
 targettitle: taking you to mpfs-icicle-kit-es-icicle-kit-user-guide-icicle-kit-user-guide.md
 time: 0

--- a/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/lc-mpfs-dev-kit_LC-MPFS-DEV-KIT_user_guide.md
+++ b/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/lc-mpfs-dev-kit_LC-MPFS-DEV-KIT_user_guide.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/lc-mpfs-dev-kit_LC-MPFS-DEV-KIT_user_guide
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/reference-designs-fpga-and-development-kits/lc-mpfs-dev-kit-user-guide.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/lc-mpfs-dev-kit/LC-MPFS-DEV-KIT_user_guide.md
 targetname: lc-mpfs-dev-kit_LC-MPFS-DEV-KIT_user_guide
 targettitle: taking you to lc-mpfs-dev-kit_LC-MPFS-DEV-KIT_user_guide
 time: 0

--- a/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/mpfs-dev-kit_MPFS-DEV-KIT_user_guide.md
+++ b/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/mpfs-dev-kit_MPFS-DEV-KIT_user_guide.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/mpfs-dev-kit_MPFS-DEV-KIT_user_guide
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/reference-designs-fpga-and-development-kits/mpfs-dev-kit-user-guide.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/mpfs-dev-kit/MPFS-DEV-KIT_user_guide.md
 targetname: mpfs-dev-kit_MPFS-DEV-KIT_user_guide
 targettitle: taking you to mpfs-dev-kit_MPFS-DEV-KIT_user_guide
 time: 0

--- a/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/updating-icicle-kit_updating-icicle-kit-design-and-linux.md
+++ b/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/updating-icicle-kit_updating-icicle-kit-design-and-linux.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/updating-icicle-kit_updating-icicle-kit-design-and-linux
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/reference-designs-fpga-and-development-kits/icicle-kit-user-guide.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/boards/mpfs-icicle-kit-es/icicle-kit-user-guide/icicle-kit-user-guide.md
 targetname: boards-mpfs-icicle-kit-es-icicle-kit-user-guide
 targettitle: boards-mpfs-icicle-kit-es-icicle-kit-user-guide
 time: 0


### PR DESCRIPTION
Reverts Mi-V-Ecosystem/mi-v-ecosystem.github.io#75
This change is to be merged along with the doc repo update.