### PR TITLE
redirect link: rename "PolarFire SoC sev kit" to "PolarFire SoC Video…

### DIFF
--- a/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-guides-mpfs-sev-h264-demo.md
+++ b/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-guides-mpfs-sev-h264-demo.md
@@ -1,9 +1,0 @@
----
-layout: forward
-permalink: /redirects/demo-guides-mpfs-sev-h264-demo
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/demo-guides/mpfs-sev-h264-demo.md
-targetname: demo-guides-mpfs-sev-h264-demo
-targettitle: taking you to demo-guides-mpfs-sev-h264-demo
-time: 0
-message: this page has moved
----

--- a/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-guides-mpfs-video-h264-demo.md
+++ b/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-guides-mpfs-video-h264-demo.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/demo-guides-mpfs-sev-h264-demo
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/applications-and-demos/mpfs-video-kit-h264-demo.md
+targetname: applications-and-demos-mpfs-video-kit-h264-demo
+targettitle: taking you to applications-and-demos-mpfs-video-kit-h264-demo
+time: 0
+message: this page has moved
+---


### PR DESCRIPTION
… Kit"

The existing h264 demo redirect link released on the GitHub uses the name "sev-kit" for the Polarfire SoC Video Kit platform. This change replaces all such instances with the correct name.

Signed-off-by: Shravan Chippa <shravan.chippa@microchip.com>