### PR TITLE
redirect link: Rename "PolarFire SoC sev kit" to "PolarFire SoC Video…

### DIFF
--- a/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/boards-mpfs-sev-kit-sev-kit-user-guide.md
+++ b/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/boards-mpfs-sev-kit-sev-kit-user-guide.md
@@ -1,9 +1,9 @@
 ---
 layout: forward
 permalink: /redirects/boards-mpfs-sev-kit-sev-kit-user-guide
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/reference-designs-fpga-and-development-kits/sev-kit-user-guide.md
-targetname: boards-mpfs-sev-kit-sev-kit-user-guide
-targettitle: taking you to boards-mpfs-sev-kit-sev-kit-user-guide
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/reference-designs-fpga-and-development-kits/mpfs-video-kit-user-guide.md
+targetname: boards-mpfs-video-kit-mpfs-video-kit-user-guide
+targettitle: taking you to boards-mpfs-video-kit-video-kit-user-guide
 time: 0
 message: this page has moved
 ---


### PR DESCRIPTION
… Kit"

The existing redirect link released on the GitHub uses the name "sev-kit" for the Polarfire SoC Video Kit platform. This change replaces all such instances with the correct name.