### PR TITLE
redirect link PolarFire SoC Video Kit user guid: typo correction

### DIFF
--- a/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/boards-mpfs-sev-kit-sev-kit-user-guide.md
+++ b/_redirects/polarfire-soc/documentation/Reference-Designs-FPGA-and-development-kits/boards-mpfs-sev-kit-sev-kit-user-guide.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/boards-mpfs-sev-kit-sev-kit-user-guide
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/reference-designs-fpga-and-development-kits/mpfs-video-kit-user-guide.md
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/reference-designs-fpga-and-development-kits/mpfs-video-kit-user-guide.md
 targetname: boards-mpfs-video-kit-mpfs-video-kit-user-guide
 targettitle: taking you to boards-mpfs-video-kit-video-kit-user-guide
 time: 0


### PR DESCRIPTION
Fixes: b26b96bf1506 ("redirect link: Rename "PolarFire SoC sev kit" to "PolarFire SoC Video Kit"")