### PR TITLE
redirect link: Rename "PolarFire SoC sev kit" to "PolarFire SOC Video…

### DIFF
--- a/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-guides-mpfs-sev-h264-demo.md
+++ b/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-guides-mpfs-sev-h264-demo.md
@@ -1,9 +1,9 @@
 ---
 layout: forward
 permalink: /redirects/demo-guides-mpfs-sev-h264-demo
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/applications-and-demos/mpfs-sev-h264-demo.md
-targetname: demo-guides-mpfs-sev-h264-demo
-targettitle: taking you to demo-guides-mpfs-sev-h264-demo
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/blob/master/applications-and-demos/mpfs-video-kit-h264-demo.md
+targetname: demo-guides-mpfs-video-kit-h264-demo
+targettitle: taking you to demo-guides-mpfs-video-kit-h264-demo
 time: 0
 message: this page has moved
 ---


### PR DESCRIPTION
… Kit"

The existing redirect link released on the GitHub uses the name "sev-kit" for the Polarfire SoC Video Kit platform. This change replaces all such instances with the correct name.