### PR TITLE
Add redirects for the polarfire-soc-yocto-manifests repo and Ubuntu Server Image

### DIFF
--- a/_redirects/polarfire-soc/external/icicle-kit-ubuntu-server-image.md
+++ b/_redirects/polarfire-soc/external/icicle-kit-ubuntu-server-image.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/icicle-kit-ubuntu-server-image
+target: https://cdimage.ubuntu.com/releases/jammy/release/
+targetname: icicle-kit-ubuntu-server-image
+targettitle: taking you to icicle-kit-ubuntu-server-image
+time: 0
+message: this page has moved
+---

--- a/_redirects/polarfire-soc/repos/repo-polarfire-soc-yocto-manifests.md
+++ b/_redirects/polarfire-soc/repos/repo-polarfire-soc-yocto-manifests.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-polarfire-soc-yocto-manifests
+target: https://github.com/polarfire-soc/polarfire-soc-yocto-manifests
+targetname: repo-polarfire-soc-yocto-manifests
+targettitle: taking you to repo-polarfire-soc-yocto-manifests
+time: 0
+message: this page has moved
+---


### PR DESCRIPTION
Add a redirect for the new polarfire-soc-yocto-manifests repository and another one to point to the Icicle Kit Ubuntu Server Image (Jammy Jellyfish)
