### PR TITLE
Redirect link: Rename "PolarFire SoC sev kit" to "PolarFire SOC Video…

### DIFF
--- a/_redirects/polarfire-soc/repos/repo-sev-kit-reference-design.md
+++ b/_redirects/polarfire-soc/repos/repo-sev-kit-reference-design.md
@@ -1,9 +1,9 @@
 ---
 layout: forward
 permalink: /redirects/repo-sev-kit-reference-design
-target: https://github.com/polarfire-soc/sev-kit-reference-design
-targetname: repo-sev-kit-reference-design
-targettitle: taking you to repo-sev-kit-reference-design
+target: https://github.com/polarfire-soc/polarfire-soc-video-kit-reference-design
+targetname: repo-polarfire-soc-video-kit-reference-design
+targettitle: taking you to repo-polarfire-soc-video-kit-reference-design
 time: 0
 message: this page has moved
 ---


### PR DESCRIPTION
… Kit"

The existing redirect link released on the GitHub uses the name "sev-kit" for the Polarfire SoC Video Kit platform. This change replaces all such instances with the correct name.