### PR TITLE
benchmarking: dma: add redirect links for doc

### DIFF
--- a/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-guides-mpfs-dma-benchmarking.md
+++ b/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-guides-mpfs-dma-benchmarking.md
@@ -1,9 +1,0 @@
----
-layout: forward
-permalink: /redirects/demo-guides_mpfs-dma-benchmarking
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/knowledge-base/mpfs-dma-benchmarking.md
-targetname: demo-guides_mpfs-dma-benchmarking
-targettitle: demo-guides_mpfs-dma-benchmarking
-time: 0
-message: this page has moved
----

--- a/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-mpfs-dma-benchmarking.md
+++ b/_redirects/polarfire-soc/documentation/Applications-and-Demos/demo-mpfs-dma-benchmarking.md
@@ -1,9 +1,0 @@
----
-layout: forward
-permalink: /redirects/demo-mpfs-dma-benchmarking
-target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/knowledge-base/mpfs-dma-benchmarking.md
-targetname: demo-mpfs-dma-benchmarking
-targettitle: taking you to demo-mpfs-dma-benchmarking
-time: 0
-message: this page has moved
----

--- a/_redirects/polarfire-soc/documentation/benchmarks/dma-benchmarking/Readme.md
+++ b/_redirects/polarfire-soc/documentation/benchmarks/dma-benchmarking/Readme.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/polarfire-soc/benchmarks/Readme
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/benchmarks/dma-benchmarking/Readme.md
+targetname: dma-benchmarking_readme
+targettitle: taking you to dma-benchmarking_readme
+time: 0
+message: this page has moved
+---

--- a/_redirects/polarfire-soc/documentation/benchmarks/dma-benchmarking/benchmarking-results/concurrent-dma-benchmarking.md
+++ b/_redirects/polarfire-soc/documentation/benchmarks/dma-benchmarking/benchmarking-results/concurrent-dma-benchmarking.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/polarfire-soc/benchmarks/concurrent-dma-benchmarking
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/benchmarks/dma-benchmarking/benchmarking-results/concurrent-dma-benchmarking.md
+targetname: concurrent-dma-benchmarking
+targettitle: taking you to concurrent-dma-benchmarking
+time: 0
+message: this page has moved
+---

--- a/_redirects/polarfire-soc/documentation/benchmarks/dma-benchmarking/benchmarking-results/fabric-dma-benchmarking.md
+++ b/_redirects/polarfire-soc/documentation/benchmarks/dma-benchmarking/benchmarking-results/fabric-dma-benchmarking.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/polarfire-soc/benchmarks/fabric-dma-benchmarking
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/benchmarks/dma-benchmarking/benchmarking-results/fabric-dma-benchmarking.md
+targetname: fabric-dma-benchmarking
+targettitle: taking you to fabric-dma-benchmarking
+time: 0
+message: this page has moved
+---

--- a/_redirects/polarfire-soc/documentation/benchmarks/dma-benchmarking/benchmarking-results/mss-pdma-benchmarking.md
+++ b/_redirects/polarfire-soc/documentation/benchmarks/dma-benchmarking/benchmarking-results/mss-pdma-benchmarking.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/polarfire-soc/benchmarks/mss-pdma-benchmarking
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/benchmarks/dma-benchmarking/benchmarking-results/mss-pdma-benchmarking.md
+targetname: mss-pdma-benchmarking
+targettitle: taking you to mss-pdma-benchmarking
+time: 0
+message: this page has moved
+---

--- a/_redirects/polarfire-soc/misc-links/polarfire-soc-bare-metal-examples-applications-benchmarks-dma_benchmarking-mpfs-dma-benchmarking.md
+++ b/_redirects/polarfire-soc/misc-links/polarfire-soc-bare-metal-examples-applications-benchmarks-dma_benchmarking-mpfs-dma-benchmarking.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/polarfire-soc-bare-metal-examples-applications-benchmarks-dma_benchmarking-mpfs-dma-benchmarking
+target: https://github.com/polarfire-soc/polarfire-soc-bare-metal-examples/tree/main/applications/benchmarks/dma_benchmarking/mpfs-dma-benchmarking
+targetname: polarfire-soc-bare-metal-examples-applications-benchmarks-dma_benchmarking-mpfs-dma-benchmarking
+targettitle: taking you to polarfire-soc-bare-metal-examples-applications-benchmarks-dma_benchmarking-mpfs-dma-benchmarking
+time: 0
+message: this page has moved
+---

--- a/_redirects/polarfire-soc/misc-links/polarfire-soc-bare-metal-examples-driver-examples-fpga-ip-coreaxi4dmacontroller-coreaxi4dma-stream.md
+++ b/_redirects/polarfire-soc/misc-links/polarfire-soc-bare-metal-examples-driver-examples-fpga-ip-coreaxi4dmacontroller-coreaxi4dma-stream.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/polarfire-soc-bare-metal-examples-driver-examples-fpga-ip-coreaxi4dmacontroller-coreaxi4dma-stream
+target: https://github.com/polarfire-soc/polarfire-soc-bare-metal-examples/tree/main/driver-examples/fpga-ip/CoreAXI4DMAController/coreaxi4dma-stream
+targetname: coreaxi4dmacontroller_coreaxi4dma-stream
+targettitle: taking you to CoreAXI4DMAController CoreAXI4DMA Stream
+time: 0
+message: this page has moved
+--- 


### PR DESCRIPTION
adding redirect links relating to dma benchmarking documentation
- benchmarking overview 
- concurrent dma benchmarking
- fabric dma benchmarking
- pdma benchmarking -> deleted old redirect links relating to these

Add the following re-direct links for bare metal projects:
- coreaxi4dma controller stream-example
- pdma benchmarking application bare metal project