### PR TITLE
Add redirects for several HSS and Linux related documents

### DIFF
--- a/_redirects/polarfire-soc/documentation/HSS-and-U-Boot/hart-software-services-profiling.md
+++ b/_redirects/polarfire-soc/documentation/HSS-and-U-Boot/hart-software-services-profiling.md
@@ -1,0 +1,8 @@
+---
+layout: forward
+permalink: /redirects/hart-software-services-profiling
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/hss-and-u-boot/profiling.md
+targetname: hart-software-services-profiling
+time: 0
+message: this page has moved
+---

--- a/_redirects/polarfire-soc/documentation/HSS-and-U-Boot/hart-software-services-reboot.md
+++ b/_redirects/polarfire-soc/documentation/HSS-and-U-Boot/hart-software-services-reboot.md
@@ -1,0 +1,8 @@
+---
+layout: forward
+permalink: /redirects/hart-software-services-reboot
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/hss-and-u-boot/reboot.md
+targetname: hart-software-services-reboot
+time: 0
+message: this page has moved
+---

--- a/_redirects/polarfire-soc/documentation/How-To/linux-boot-authentication.md
+++ b/_redirects/polarfire-soc/documentation/How-To/linux-boot-authentication.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/linux-boot-authentication
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/how-to/linux-boot-authentication.md
+targetname: linux-boot-authentication
+targettitle: taking you to linux-boot-authentication
+time: 0
+message: this page has moved
+---

--- a/_redirects/polarfire-soc/documentation/How-To/re-programming-the-fpga-from-linux.md
+++ b/_redirects/polarfire-soc/documentation/How-To/re-programming-the-fpga-from-linux.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/re-programming-the-fpga-from-linux
+target: https://github.com/polarfire-soc/polarfire-soc-documentation/tree/master/how-to/re-programming-the-fpga-from-linux.md
+targetname: re-programming-the-fpga-from-linux
+targettitle: taking you to re-programming-the-fpga-from-linux
+time: 0
+message: this page has moved
+---


### PR DESCRIPTION
Add new 4 redirects for:
HSS reboot documentation
HSS profiling documentation
Linux authenticated boot
Re-programming the FPGA from Linux (auto update)