### PR TITLE
CoreAXI4DMAController example: fix broken link

### DIFF
--- a/_redirects/polarfire-soc/misc-links/polarfire-soc-bare-metal-examples-driver-examples-fpga-ip-coreaxi4dmacontroller-coreaxi4dma-stream.md
+++ b/_redirects/polarfire-soc/misc-links/polarfire-soc-bare-metal-examples-driver-examples-fpga-ip-coreaxi4dmacontroller-coreaxi4dma-stream.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/polarfire-soc-bare-metal-examples-driver-examples-fpga-ip-coreaxi4dmacontroller-coreaxi4dma-stream
-target: https://github.com/polarfire-soc/polarfire-soc-bare-metal-examples/tree/main/driver-examples/fpga-ip/CoreAXI4DMAController/coreaxi4dma-stream
+target: https://github.com/polarfire-soc/polarfire-soc-bare-metal-examples/tree/main/driver-examples/fpga-ip/CoreAXI4DMAController/mpfs-coreaxi4dma-stream
 targetname: coreaxi4dmacontroller_coreaxi4dma-stream
 targettitle: taking you to CoreAXI4DMAController CoreAXI4DMA Stream
 time: 0


### PR DESCRIPTION
Fix broken redirect link that was supposed to point to the new coreaxi4dmacontroller stream example project.