### PR TITLE
New redirect: Core10GBaseKR_PHY IP UG

### DIFF
--- a/_redirects/mi-v-soft-risc-v/ip-user-guides/miv-rv32-ip-user-guide-core10gbasekr_phy.md
+++ b/_redirects/mi-v-soft-risc-v/ip-user-guides/miv-rv32-ip-user-guide-core10gbasekr_phy.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/miv-rv32-ip-user-guide-core10gbasekr_phy
+target: https://ww1.microchip.com/downloads/aemDocuments/documents/FPGA/ProductDocuments/UserGuides/ip_cores/directcores/Core10GBaseKR_PHY_UG.pdf
+targetname: miv-rv32-ip-user-guide-core10gbasekr_phy
+targettitle: taking you to miv-rv32-ip-user-guide-core10gbasekr_phy
+time: 0
+message: this page has moved
+---


### PR DESCRIPTION
Added a redirect to the Core10GBaseKR_PHY IP user guide which is linked in the embedded software driver.