### PR TITLE
Add redirect for MiV avalanche fpga designs

### DIFF
--- a/_redirects/mi-v-soft-risc-v/repos/repo-future-avalanche-board-mi-v-sample-fpga-designs.md
+++ b/_redirects/mi-v-soft-risc-v/repos/repo-future-avalanche-board-mi-v-sample-fpga-designs.md
@@ -1,0 +1,9 @@
+---
+layout: forward
+permalink: /redirects/repo-future-avalanche-board-mi-v-sample-fpga-designs
+target: https://github.com/Mi-V-Soft-RISC-V/Future-Avalanche-Board/tree/main/Libero_Projects
+targetname: repo-future-avalanche-board-mi-v-sample-fpga-designs
+targettitle: taking you to repo-future-avalanche-board-mi-v-sample-fpga-designs
+time: 0
+message: this page has moved
+---


### PR DESCRIPTION
Add a redirect link for the MiV sample FPGA designs on the Future electronics Avalanche board.