### PR TITLE
Update Yocto redirects

### DIFF
--- a/_redirects/polarfire-soc/repos/releases/releases-meta-polarfire-soc-yocto-bsp.md
+++ b/_redirects/polarfire-soc/repos/releases/releases-meta-polarfire-soc-yocto-bsp.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/releases-meta-polarfire-soc-yocto-bsp
-target: https://github.com/polarfire-soc/meta-polarfire-soc-yocto-bsp/releases
+target: https://github.com/linux4microchip/meta-mchp/releases
 targetname: releases-meta-polarfire-soc-yocto-bsp
 targettitle: taking you to releases-meta-polarfire-soc-yocto-bsp
 time: 0

--- a/_redirects/polarfire-soc/repos/repo-meta-polarfire-soc-yocto-bsp.md
+++ b/_redirects/polarfire-soc/repos/repo-meta-polarfire-soc-yocto-bsp.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/repo-meta-polarfire-soc-yocto-bsp
-target: https://github.com/polarfire-soc/meta-polarfire-soc-yocto-bsp
+target: https://github.com/linux4microchip/meta-mchp/tree/HEAD/meta-mchp-polarfire-soc
 targetname: repo-meta-polarfire-soc-yocto-bsp
 targettitle: taking you to repo-meta-polarfire-soc-yocto-bsp
 time: 0

--- a/_redirects/polarfire-soc/repos/repo-polarfire-soc-yocto-manifests.md
+++ b/_redirects/polarfire-soc/repos/repo-polarfire-soc-yocto-manifests.md
@@ -1,7 +1,7 @@
 ---
 layout: forward
 permalink: /redirects/repo-polarfire-soc-yocto-manifests
-target: https://github.com/polarfire-soc/polarfire-soc-yocto-manifests
+target: https://github.com/linux4microchip/meta-mchp-manifest
 targetname: repo-polarfire-soc-yocto-manifests
 targettitle: taking you to repo-polarfire-soc-yocto-manifests
 time: 0


### PR DESCRIPTION
Update Yocto redirects to target new [meta-mchp](https://github.com/linux4microchip/meta-mchp) Yocto repository